### PR TITLE
Update API host and version to v1

### DIFF
--- a/myscript.pl
+++ b/myscript.pl
@@ -19,7 +19,7 @@ $ua->timeout(10);
 $ua->env_proxy;
 
 # build the URL
-my $uri = URI->new("http://api.metacpan.org/v0/search/autocomplete");
+my $uri = URI->new("https://fastapi.metacpan.org/v1/search/autocomplete");
 $uri->query_form( q => $ENV{SEARCH_QUERY} );
 
 # get the data


### PR DESCRIPTION
I think new fatpacking may be in order:

```
bash-3.2$ SEARCH_QUERY=plack perl -Ifatlib myscript.pl
\C no longer supported in regex; marked by <-- HERE in m/(\ <-- HERE C)/ at fatlib/URI/Escape.pm line 205.
Compilation failed in require at fatlib/URI.pm line 22.
BEGIN failed--compilation aborted at fatlib/URI.pm line 22.
Compilation failed in require at myscript.pl line 11.
BEGIN failed--compilation aborted at myscript.pl line 11.
```